### PR TITLE
fix: pin Speakeasy CLI and Terraform generator to avoid UseHoistedValue bug

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -14,7 +14,7 @@ jobs:
         with:
             force: ${{ github.event.inputs.force }}
             mode: pr
-            speakeasy_version: latest
+            speakeasy_version: 1.685.3
         secrets:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -29,7 +29,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 0.19.1
+  version: 0.18.4
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}


### PR DESCRIPTION
## Summary

- Pins `speakeasy_version` in the generation workflow to `1.685.3` (was `latest`)
- Reverts `terraform: version` in `gen.yaml` to `0.18.4` (from `0.19.1`)

## Root cause

Speakeasy CLI `1.761.0` auto-upgraded the Terraform generator from `0.18.4` → `0.19.1` when regeneration was run in commit `93ea669` to pick up `file_size_bytes`/`_manifest` fields. Generator `0.19.1` introduced `UseHoistedValue` plan modifiers for `default_value` across all attribute subtypes.

**The bug**: on CREATE (all state is unknown), `UseHoistedValue` returns early, leaving `default_value` UNKNOWN in the plan. After apply, `RefreshFromSharedAttributeWithCompositeID` never sets the top-level `r.DefaultValue`, so Terraform throws:

> Provider returned invalid result object after apply — unknown value for default_value

This only affects **creates** (not updates), since on update prior state exists and `UseHoistedValue` can resolve the value.

## Impact

Any blueprint install that creates new schema attributes with a `default_value` field fails with `terraform_apply_error`. Observed in prod job `17de57f8-c21b-4bd0-8e9a-8b9863b455b4` — 7 Contact entity schema attributes (consent/status/date types).

## Fix

Pinning the Speakeasy CLI version ensures the generator version stays at `0.18.4`, which generates `default_value` as `Optional + Computed` with no plan modifier — working correctly on both CREATE and UPDATE.

Once this is merged and a new provider version is released (5.14.0), `blueprint-manifest-api/providers.tf` should be updated to that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)